### PR TITLE
By-receptive-field interpolation at predict time ; parameterization of transforms ; PointNet++ support

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -49,7 +49,7 @@ jobs:
         python -m 
         myria3d.predict
         --config-path /inputs/
-        --config-name predict_config_V2.0.0.yaml
+        --config-name predict_config_V2.1.0.yaml
         predict.src_las=/inputs/792000_6272000_subset_buildings.las
         predict.output_dir=/outputs/
         predict.ckpt_path=/inputs/RandLaNet_Buildings_B2V0.5_epoch_033.ckpt

--- a/configs/callbacks/default.yaml
+++ b/configs/callbacks/default.yaml
@@ -22,7 +22,6 @@ log_iou_by_class:
     interpolation_k: ${predict.interpolation_k}
     classification_dict: ${datamodule.dataset_description.classification_dict}
     probas_to_save: ${predict.probas_to_save}  # replace by a list of string of class names to select specific probas to save
-    output_dir: null # Replace by an output to save resultsduring test
 
 model_checkpoint:
   _target_: pytorch_lightning.callbacks.ModelCheckpoint

--- a/configs/datamodule/datamodule.yaml
+++ b/configs/datamodule/datamodule.yaml
@@ -14,4 +14,3 @@ augment: false  # activate data augmentation
 
 defaults:
   - dataset_description: 20220204_BuildingValidation_and_Ground.yaml
-  - subsampler: grid.yaml

--- a/configs/datamodule/datamodule.yaml
+++ b/configs/datamodule/datamodule.yaml
@@ -6,7 +6,8 @@ prepared_data_dir: ${oc.env:PREPARED_DATA_DIR}
 test_data_dir: ${datamodule.prepared_data_dir}/test/
 
 batch_size: 32
-num_workers: 16  # for data loaders
+prefetch_factor: 2
+num_workers: 2  # for data loaders
 subtile_width_meters: 50  # size of receptive fields : 50mx50m
 subtile_overlap: ${predict.subtile_overlap}  # Used for test and predict phases only
 

--- a/configs/datamodule/datamodule.yaml
+++ b/configs/datamodule/datamodule.yaml
@@ -15,3 +15,4 @@ augment: false  # activate data augmentation
 
 defaults:
   - dataset_description: 20220204_BuildingValidation_and_Ground.yaml
+  - transforms: default.yaml

--- a/configs/datamodule/subsampler/fps.yaml
+++ b/configs/datamodule/subsampler/fps.yaml
@@ -1,2 +1,0 @@
-_target_: myria3d.data.transforms.FPSSampler
-subsample_size: 12500

--- a/configs/datamodule/subsampler/grid.yaml
+++ b/configs/datamodule/subsampler/grid.yaml
@@ -1,3 +1,0 @@
-_target_: myria3d.data.transforms.CustomGridSampler
-subsample_size: 12500
-voxel_size: 0.25

--- a/configs/datamodule/subsampler/random.yaml
+++ b/configs/datamodule/subsampler/random.yaml
@@ -1,2 +1,0 @@
-_target_: myria3d.data.transforms.RandomSampler
-subsample_size: 12500

--- a/configs/datamodule/transforms/augmentations/default.yaml
+++ b/configs/datamodule/transforms/augmentations/default.yaml
@@ -1,0 +1,11 @@
+x_flip:
+  _target_: torch_geometric.transforms.RandomFlip
+  _args_:
+    - 0
+  p: 0.5
+  
+y_flip:
+  _target_: torch_geometric.transforms.RandomFlip
+  _args_:
+    - 2
+  p: 0.5

--- a/configs/datamodule/transforms/default.yaml
+++ b/configs/datamodule/transforms/default.yaml
@@ -1,0 +1,9 @@
+defaults:
+  - preparations: default.yaml
+  - augmentations: default.yaml
+  - normalizations: default.yaml
+
+# trun these dict into ListConfig
+augmentations_list: "${oc.dict.values: datamodule.transforms.augmentations}"
+preparations_list: "${oc.dict.values: datamodule.transforms.preparations}"
+normalizations_list: "${oc.dict.values: datamodule.transforms.normalizations}"

--- a/configs/datamodule/transforms/normalizations/default.yaml
+++ b/configs/datamodule/transforms/normalizations/default.yaml
@@ -1,0 +1,5 @@
+NormalizePos:
+  _target_: myria3d.data.transforms.NormalizePos
+
+StandardizeFeatures:
+  _target_: myria3d.data.transforms.StandardizeFeatures

--- a/configs/datamodule/transforms/preparations/default.yaml
+++ b/configs/datamodule/transforms/preparations/default.yaml
@@ -1,0 +1,29 @@
+EmptySubtileFilter:
+  _target_: myria3d.data.transforms.EmptySubtileFilter
+
+ToTensor:
+  _target_: myria3d.data.transforms.ToTensor
+
+TargetTransform:
+  _target_: myria3d.data.transforms.TargetTransform
+  _args_:
+    - ${datamodule.dataset_description.classification_preprocessing_dict}
+    - ${datamodule.dataset_description.classification_dict}
+
+GridSampling:
+  _target_: torch_geometric.transforms.GridSampling
+  _args_:
+    - 0.25
+
+FixedPoints:
+  _target_: torch_geometric.transforms.FixedPoints
+  _args_:
+    - 12500
+  replace: False
+  allow_duplicates: True
+
+CopySampledPos:
+  _target_: myria3d.data.transforms.CopySampledPos
+
+Center:
+  _target_: torch_geometric.transforms.Center

--- a/configs/experiment/PointNet2Debug.yaml
+++ b/configs/experiment/PointNet2Debug.yaml
@@ -1,0 +1,27 @@
+# @package _global_
+
+defaults:
+  - override /trainer: default.yaml
+  - override /model: point_net_2_model.yaml
+
+# all parameters below will be merged with parameters from default configurations set above
+# this allows you to overwrite only specified parameters
+
+logger:
+  comet:
+    experiment_name: "PointNet2Debug"
+
+trainer:
+  log_every_n_steps: 1
+  overfit_batches: 1
+  num_sanity_val_steps: 0
+  min_epochs: 40
+  max_epochs: 40
+  check_val_every_n_epoch: 1
+  # gpus: "1"
+
+datamodule:
+  augment: false
+  batch_size: 16
+  num_workers: 1
+

--- a/configs/model/point_net_2_model.yaml
+++ b/configs/model/point_net_2_model.yaml
@@ -1,0 +1,11 @@
+defaults:
+  - default.yaml
+
+lr: 0.001  # from PN2 paper - quite sensitive!
+
+neural_net_class_name: "PointNet2"
+neural_net_hparams:
+  d_in: ${model.d_in}  # 3 (xyz) + num of features
+  num_classes: "${model.num_classes}"
+  r1: 0.04  # 2/50
+  r2: 0.08  # 4/50

--- a/docs/source/apidoc/default_config.yml
+++ b/docs/source/apidoc/default_config.yml
@@ -58,7 +58,6 @@ callbacks:
       interpolation_k: ${predict.interpolation_k}
       classification_dict: ${datamodule.dataset_description.classification_dict}
       probas_to_save: ${predict.probas_to_save}
-      output_dir: null
   model_checkpoint:
     _target_: pytorch_lightning.callbacks.ModelCheckpoint
     monitor: val/loss_epoch

--- a/docs/source/apidoc/default_config.yml
+++ b/docs/source/apidoc/default_config.yml
@@ -31,10 +31,6 @@ datamodule:
       _target_: functools.partial
       _args_:
       - ${get_method:myria3d.data.loading.FrenchLidarDataLogic.load_las}
-  subsampler:
-    _target_: myria3d.data.transforms.CustomGridSampler
-    subsample_size: 12500
-    voxel_size: 0.25
   _target_: myria3d.data.datamodule.DataModule
   prepared_data_dir: ${oc.env:PREPARED_DATA_DIR}
   test_data_dir: ${datamodule.prepared_data_dir}/test/

--- a/myria3d/callbacks/logging_callbacks.py
+++ b/myria3d/callbacks/logging_callbacks.py
@@ -1,4 +1,8 @@
+from tempfile import tempdir
+import tempfile
 from typing import Any, Dict, Optional
+import numpy as np
+import pdal
 
 import pytorch_lightning as pl
 from pytorch_lightning import Callback
@@ -60,7 +64,7 @@ class LogIoUByClass(Callback):
     ):
         """Log IoU for each class."""
         logits = outputs["logits"]
-        targets = outputs["targets"]
+        targets = batch.y
         self.log_iou(logits, targets, "train", self.train_iou_by_class_dict)
 
     def on_validation_batch_end(
@@ -74,7 +78,7 @@ class LogIoUByClass(Callback):
     ):
         """Log IoU for each class."""
         logits = outputs["logits"]
-        targets = outputs["targets"]
+        targets = batch.y
         self.log_iou(logits, targets, "val", self.val_iou_by_class_dict)
 
     def on_test_batch_end(
@@ -87,16 +91,9 @@ class LogIoUByClass(Callback):
         dataloader_idx: int,
     ):
         """Log IoU for each class. Loop in case of multiple files in a single batch."""
-        interpolations = self.itp.update(outputs)
-        for logits, targets in interpolations:
-            self.log_iou(logits, targets, "test", self.test_iou_by_class_dict)
-
-    def on_test_epoch_end(self, trainer: pl.Trainer, pl_module: pl.LightningModule):
-        interpolation = self.itp._interpolate()
-        logits, targets = interpolation
+        logits = outputs["logits"]
+        targets = batch.y
         self.log_iou(logits, targets, "test", self.test_iou_by_class_dict)
-        if self.itp.output_dir:
-            self.itp._write(interpolation)
 
     def log_iou(self, logits, targets, phase: str, iou_dict):
         device = logits.device

--- a/myria3d/callbacks/logging_callbacks.py
+++ b/myria3d/callbacks/logging_callbacks.py
@@ -1,8 +1,4 @@
-from tempfile import tempdir
-import tempfile
 from typing import Any, Dict, Optional
-import numpy as np
-import pdal
 
 import pytorch_lightning as pl
 from pytorch_lightning import Callback

--- a/myria3d/data/datamodule.py
+++ b/myria3d/data/datamodule.py
@@ -46,6 +46,7 @@ class DataModule(LightningDataModule):
         self.subtile_width_meters = kwargs.get("subtile_width_meters", 50)
         self.subtile_overlap = kwargs.get("subtile_overlap", 0)
         self.batch_size = kwargs.get("batch_size", 32)
+        self.prefetch_factor = kwargs.get("prefetch_factor", 2)
         self.augment = kwargs.get("augment", False)
 
         self.dataset_description = kwargs.get("dataset_description")
@@ -127,7 +128,7 @@ class DataModule(LightningDataModule):
             batch_size=self.batch_size,
             shuffle=True,
             num_workers=self.num_workers,
-            prefetch_factor=1,
+            prefetch_factor=self.prefetch_factor,
         )
 
     def val_dataloader(self):
@@ -136,7 +137,7 @@ class DataModule(LightningDataModule):
             dataset=self.val_data,
             batch_size=self.batch_size,
             num_workers=self.num_workers,
-            prefetch_factor=1,
+            prefetch_factor=self.prefetch_factor,
         )
 
     def test_dataloader(self):
@@ -150,7 +151,7 @@ class DataModule(LightningDataModule):
             batch_size=self.batch_size,
             shuffle=False,
             num_workers=1,  # b/c terable dataloader
-            prefetch_factor=1,
+            prefetch_factor=self.prefetch_factor,
         )
 
     def predict_dataloader(self):
@@ -164,7 +165,7 @@ class DataModule(LightningDataModule):
             batch_size=self.batch_size,
             shuffle=False,
             num_workers=1,  # b/c terable dataloader
-            prefetch_factor=1,
+            prefetch_factor=self.prefetch_factor,
         )
 
     def _set_all_transforms(self):

--- a/myria3d/data/datamodule.py
+++ b/myria3d/data/datamodule.py
@@ -13,6 +13,7 @@ from torch_geometric.data.data import Data
 import torch_geometric.transforms as T
 from myria3d.utils import utils
 from myria3d.data.transforms import (
+    CopyTargets,
     CustomCompose,
     EmptySubtileFilter,
     CopySampledPos,
@@ -175,6 +176,7 @@ class DataModule(LightningDataModule):
         self.preparation = [
             EmptySubtileFilter(),  # TODO: take care of this at preparation time
             ToTensor(),
+            CopyTargets(),
             TargetTransform(
                 self.classification_preprocessing_dict, self.classification_dict
             ),

--- a/myria3d/data/datamodule.py
+++ b/myria3d/data/datamodule.py
@@ -8,19 +8,9 @@ import torch
 from torch.utils.data import Dataset
 from torch_geometric.loader import DataLoader
 from torch.utils.data.dataset import IterableDataset
-from torch_geometric.transforms import RandomFlip
 from torch_geometric.data.data import Data
-import torch_geometric.transforms as T
 from myria3d.utils import utils
-from myria3d.data.transforms import (
-    CustomCompose,
-    EmptySubtileFilter,
-    CopySampledPos,
-    NormalizePos,
-    StandardizeFeatures,
-    TargetTransform,
-    ToTensor,
-)
+from myria3d.data.transforms import CustomCompose
 
 
 log = utils.get_logger(__name__)

--- a/myria3d/data/loading.py
+++ b/myria3d/data/loading.py
@@ -163,10 +163,12 @@ class LidarDataLogic(ABC):
         sub_tile_data.pos = sub_tile_data.pos[mask]
         sub_tile_data.x = sub_tile_data.x[mask]
         sub_tile_data.y = sub_tile_data.y[mask]
+        sub_tile_data.idx_in_original_cloud = sub_tile_data.idx_in_original_cloud[mask]
 
         data.pos = data.pos[~mask]
         data.x = data.x[~mask]
         data.y = data.y[~mask]
+        data.idx_in_original_cloud = data.idx_in_original_cloud[~mask]
         return sub_tile_data
 
     def _extract_by_x(self, data: Data) -> Data:
@@ -293,6 +295,7 @@ class FrenchLidarDataLogic(LidarDataLogic):
             y=y,
             las_filepath=las_filepath,
             x_features_names=cls.x_features_names,
+            idx_in_original_cloud=np.arange(len(pos)),
         )
 
 
@@ -379,6 +382,7 @@ class SwissTopoLidarDataLogic(LidarDataLogic):
             y=y,
             las_filepath=las_filepath,
             x_features_names=cls.x_features_names,
+            idx_in_original_cloud=np.arange(len(pos)),
         )
 
 

--- a/myria3d/data/transforms.py
+++ b/myria3d/data/transforms.py
@@ -1,4 +1,3 @@
-from enum import Enum
 from typing import Callable, Dict, List
 
 import numpy as np

--- a/myria3d/data/transforms.py
+++ b/myria3d/data/transforms.py
@@ -70,12 +70,12 @@ class ToTensor(BaseTransform):
         return data
 
 
-# class CopyTargets(BaseTransform):
-#     """Make a copy of the full cloud's positions and labels, for inference interpolation."""
+class CopyTargets(BaseTransform):
+    """Make a copy of the full cloud's positions and labels, for inference interpolation."""
 
-#     def __call__(self, data: Data):
-#         data["y_copy"] = data["y"].clone()
-#         return data
+    def __call__(self, data: Data):
+        data["y_copy"] = data["y"].clone()
+        return data
 
 
 class CopySampledPos(BaseTransform):

--- a/myria3d/data/transforms.py
+++ b/myria3d/data/transforms.py
@@ -10,13 +10,6 @@ from myria3d.utils import utils
 log = utils.get_logger(__name__)
 
 
-class ChannelNames(Enum):
-    """Names of custom additional LAS channel."""
-
-    PredictedClassification = "PredictedClassification"
-    ProbasEntropy = "entropy"
-
-
 class CustomCompose(BaseTransform):
     """
     Composes several transforms together.

--- a/myria3d/data/transforms.py
+++ b/myria3d/data/transforms.py
@@ -1,16 +1,10 @@
-import math
 from enum import Enum
-from numbers import Number
-from typing import Callable, Dict, List, Tuple
+from typing import Callable, Dict, List
 
 import numpy as np
 import torch
-import torch_geometric
-from torch_geometric.data import Batch, Data
+from torch_geometric.data import Data
 from torch_geometric.transforms import BaseTransform
-from torch_geometric.nn.pool import fps
-from torch_scatter import scatter_add, scatter_mean
-import torch.nn.functional as F
 from myria3d.utils import utils
 
 log = utils.get_logger(__name__)

--- a/myria3d/data/transforms.py
+++ b/myria3d/data/transforms.py
@@ -57,14 +57,6 @@ class ToTensor(BaseTransform):
         return data
 
 
-class CopyTargets(BaseTransform):
-    """Make a copy of the full cloud's positions and labels, for inference interpolation."""
-
-    def __call__(self, data: Data):
-        data["y_copy"] = data["y"].clone()
-        return data
-
-
 class CopySampledPos(BaseTransform):
     """Make a copy of the unormalized positions of subsampled points."""
 

--- a/myria3d/models/interpolation.py
+++ b/myria3d/models/interpolation.py
@@ -1,19 +1,22 @@
-"""How we turn from prediction made on a subsampled subset of a Las to a complete point cloud."""
-
+from enum import Enum
+import logging
 import os
-from typing import Dict, List, Optional, Literal, Union
-
+from typing import Dict, List, Literal, Union
 import pdal
 import numpy as np
 import torch
-from torch_geometric.nn.pool import knn
 from torch_geometric.nn.unpool import knn_interpolate
-from myria3d.utils import utils
 from torch.distributions import Categorical
+from torch_scatter import scatter_sum
 
-from myria3d.data.transforms import ChannelNames
+log = logging.getLogger(__name__)
 
-log = utils.get_logger(__name__)
+
+class ChannelNames(Enum):
+    """Names of custom additional LAS channel."""
+
+    PredictedClassification = "PredictedClassification"
+    ProbasEntropy = "entropy"
 
 
 class Interpolator:
@@ -24,22 +27,16 @@ class Interpolator:
         interpolation_k: int = 10,
         classification_dict: Dict[int, str] = {},
         probas_to_save: Union[List[str], Literal["all"]] = "all",
-        output_dir: Optional[str] = None,
     ):
         """Initialization method.
-
         Args:
             interpolation_k (int, optional): Number of Nearest-Neighboors for inverse-distance averaging of logits. Defaults 10.
             classification_dict (Dict[int, str], optional): Mapper from classification code to class name (e.g. {6:building}). Defaults {}.
             probas_to_save (List[str] or "all", optional): Specific probabilities to save as new LAS dimensions.
             Override with None for no saving of probabilitiues. Defaults to "all".
-            output_dir (Optional[str], optional): Directory to save output LAS with new predicted classification, entropy,
-            and probabilities. Defaults to None.
+
 
         """
-        self.output_dir = output_dir
-        if self.output_dir:
-            os.makedirs(self.output_dir, exist_ok=True)
 
         self.k = interpolation_k
         self.classification_dict = classification_dict
@@ -56,20 +53,19 @@ class Interpolator:
             class_index: class_code
             for class_index, class_code in enumerate(classification_dict.keys())
         }
+        self.logits_sub: List[torch.Tensor] = []
+        self.pos_sub: List[torch.Tensor] = []
+        self.batch_sub: List[torch.Tensor] = []
+        self.idx_in_full_cloud_list: List[np.ndarray] = []
 
-        # Tracker for current processed file.
-        self.current_f = ""
-
-    def _load_las(self, filepath: str):
+    def load_full_las_for_update(self, raw_path: str):
         """Loads a LAS and adds necessary extradim.
 
         Args:
             filepath (str): Path to LAS for which predictions are made.
-
         """
-        self.current_f = filepath
-        pipeline = pdal.Reader.las(filename=filepath)
-
+        # self.current_f = filepath
+        pipeline = pdal.Reader.las(filename=raw_path)
         new_dims = self.probas_to_save + [
             ChannelNames.PredictedClassification.value,
             ChannelNames.ProbasEntropy.value,
@@ -79,71 +75,24 @@ class Interpolator:
                 dimensions=f"=>{new_dim}"
             ) | pdal.Filter.assign(value=f"{new_dim}=0")
         pipeline.execute()
-        self.las = pipeline.arrays[0]  # named array
-
-        self.pos_las = torch.from_numpy(
-            np.asarray(
-                [
-                    self.las["X"],
-                    self.las["Y"],
-                    self.las["Z"],
-                ],
-                dtype=np.float32,
-            ).transpose()
-        )
-        self.logits_sub_l = []
-        self.targets_l = []
-        self.pos_sub_l = []
-        self.pos_l = []
+        return pipeline.arrays[0]  # named array
 
     @torch.no_grad()
-    def update(self, outputs: dict):
-        """Keep a list of predictions made so far.
-        In Test phase, interpolation and saving are trigerred when a new file is encountered.
+    def store_predictions(self, logits, pos, batch, idx_in_original_cloud):
+        """Keep a list of predictions made so far."""
+        self.logits_sub.append(logits)
+        self.pos_sub.append(pos)
+        self.idx_in_full_cloud_list += idx_in_original_cloud
+        if not self.batch_sub:
+            # starts at 0 if this is the first batch
+            self.batch_sub.append(batch)
+        else:
+            # starts from current max batch index
+            current_max_batch_idx = max(max(b) for b in self.batch_sub)
+            self.batch_sub.append(current_max_batch_idx + 1 + batch)
 
-        Args:
-            outputs (dict): Outputs of lightning's predict_step or test_step.
-
-        Returns:
-            List[interpolation]: list of interpolation made for these specific outputs. This is typically empty,
-            except when we switch from a LAS to another, at which point we need to output the result of the interpolation
-            for IoU logging by a callback.
-
-        """
-        _itps = []
-
-        batch = outputs["batch"].detach()
-        logits_b = outputs["logits"].detach()
-        some_targets_to_interpolate = "y_copy" in batch
-        if some_targets_to_interpolate:
-            # TODO: it seems that this is always done due to data transforms.
-            targets_b = batch.y_copy.detach()
-
-        for batch_idx, las_filepath in enumerate(batch.las_filepath):
-            is_a_new_tile = las_filepath != self.current_f
-            if is_a_new_tile:
-                close_previous_las_first = self.current_f != ""
-                if close_previous_las_first:
-                    interpolation = self._interpolate()
-                    if self.output_dir:
-                        self._write(interpolation)
-                    _itps += [interpolation]
-                self._load_las(las_filepath)
-
-            # subsampled elements
-            idx_x = batch.batch_x == batch_idx
-            self.logits_sub_l.append(logits_b[idx_x])
-            self.pos_sub_l.append(batch.pos_copy_subsampled[idx_x])
-
-            if some_targets_to_interpolate:
-                # non-sampled elements
-                idx_y = batch.batch_y == batch_idx
-                self.pos_l.append(batch.pos_copy[idx_y])
-                self.targets_l.append(targets_b[idx_y])
-
-        return _itps
-
-    def _interpolate(self):
+    @torch.no_grad()
+    def interpolate_logits(self, las):
         """Interpolate logits to points without predictions using an inverse-distance weightning scheme.
 
         Returns:
@@ -152,76 +101,98 @@ class Interpolator:
         """
 
         # Cat
-        pos_sub = torch.cat(self.pos_sub_l).cpu()
-        logits_sub = torch.cat(self.logits_sub_l).cpu()
+        logits_sub: torch.Tensor = torch.cat(self.logits_sub).cpu()
+        pos_sub: torch.Tensor = torch.cat(self.pos_sub).cpu()
+        batch_sub: torch.Tensor = torch.cat(self.batch_sub).cpu()
+        del self.logits_sub
+        del self.batch_sub
+
+        # create a batch for the full las
+        # concatenate
+        batch_full_cloud: torch.Tensor = torch.cat(
+            [
+                torch.full((len(a),), i)
+                for i, a in enumerate(self.idx_in_full_cloud_list)
+            ]
+        )
+        idx_in_full_cloud: np.ndarray = np.concatenate(self.idx_in_full_cloud_list)
+        del self.idx_in_full_cloud_list
+
+        # Reorganize points in original LAS to order them by batch,
+        # matching subsampled batch
+        # If required, they could be reorered back at save time by using
+        # np.argsort(current_max_batch_idx) as sorting indices.
+
+        ordered_las = las[idx_in_full_cloud]
+
+        pos_las = torch.from_numpy(
+            np.asarray(
+                [
+                    ordered_las["X"],
+                    ordered_las["Y"],
+                    ordered_las["Z"],
+                ],
+                dtype=np.float32,
+            ).transpose()
+        )
 
         # Find nn among points with predictions for all points
+        # Only interpolate within a model's receptive field zone
         logits = knn_interpolate(
             logits_sub,
             pos_sub,
-            self.pos_las,
-            batch_x=None,
-            batch_y=None,
+            pos_las,
+            batch_x=batch_sub,
+            batch_y=batch_full_cloud,
             k=self.k,
             num_workers=4,
         )
-        # If no target, returns interpolared logits (i.e. at predict time)
-        if not self.targets_l:
-            return logits, None
 
-        # Interpolate non-sampled targets if present (i.e. at test time)
-        targets = torch.cat(self.targets_l).cpu()
-        pos = torch.cat(self.pos_l).cpu()
-        assign_idx = knn(pos, self.pos_las, k=1, num_workers=4)
-        _, x_idx = assign_idx
-        targets = targets[x_idx]
-
-        return logits, targets
+        # We scatter_sum logits based on idx, in case there are multiple predictions for a point.
+        # scatter_sum reorders logitsbased on index,they therefore match las order.
+        logits = scatter_sum(logits, torch.from_numpy(idx_in_full_cloud), dim=0)
+        idx_in_full_las = np.sort(np.unique(idx_in_full_cloud))
+        return logits, idx_in_full_las
 
     @torch.no_grad()
-    def _write(self, interpolation) -> str:
+    def write(self, raw_path: str, output_dir: str) -> str:
         """Interpolate all predicted probabilites to their original points in LAS file, and save.
 
         Args:
             interpolation (torch.Tensor, torch.Tensor): output of _interpolate, of which we need the logits.
-
+            basename: str: file basename to save it with the same one
+            output_dir (Optional[str], optional): Directory to save output LAS with new predicted classification, entropy,
+            and probabilities. Defaults to None.
         Returns:
             str: path of the updated, saved LAS file.
 
         """
-
-        basename = os.path.basename(self.current_f)
-        out_f = os.path.join(self.output_dir, basename)
-        log.info(f"Updated LAS will be saved to {out_f}")
-
-        logits, _ = interpolation
+        basename = os.path.basename(raw_path)
+        las = self.load_full_las_for_update(raw_path=raw_path)
+        logits, idx_in_full_las = self.interpolate_logits(las)
 
         probas = torch.nn.Softmax(dim=1)(logits)
         for idx, class_name in enumerate(self.classification_dict.values()):
             if class_name in self.probas_to_save:
-                self.las[class_name][:] = probas[:, idx]
+                las[class_name][idx_in_full_las] = probas[:, idx]
 
         preds = torch.argmax(logits, dim=1)
         preds = np.vectorize(self.reverse_mapper.get)(preds)
-        self.las[ChannelNames.PredictedClassification.value][:] = preds
+        las[ChannelNames.PredictedClassification.value][idx_in_full_las] = preds
 
-        self.las[ChannelNames.ProbasEntropy.value][:] = Categorical(
+        las[ChannelNames.ProbasEntropy.value][idx_in_full_las] = Categorical(
             probs=probas
         ).entropy()
 
+        os.makedirs(output_dir, exist_ok=True)
+        out_f = os.path.join(output_dir, basename)
+        out_f = os.path.abspath(out_f)
+        log.info(f"Updated LAS will be saved to {out_f}.")
         log.info("Saving...")
-
         pipeline = pdal.Writer.las(
             filename=out_f, extra_dims="all", minor_version=4, dataformat_id=8
-        ).pipeline(self.las)
+        ).pipeline(las)
         pipeline.execute()
         log.info("Saved.")
-
-        return out_f
-
-    def interpolate_and_save(self):
-        """Interpolate and save in a single method, for predictions."""
-        interpolation = self._interpolate()
-        out_f = self._write(interpolation)
 
         return out_f

--- a/myria3d/models/model.py
+++ b/myria3d/models/model.py
@@ -187,7 +187,7 @@ class Model(LightningModule):
 
         """
         logits = self.forward(batch)
-        return {"logits": logits, "batch": batch}
+        return logits
 
     def get_neural_net_class(self, class_name: str) -> nn.Module:
         """A Class Factory to class of neural net based on class name.

--- a/myria3d/models/model.py
+++ b/myria3d/models/model.py
@@ -12,6 +12,8 @@ from myria3d.utils import utils
 log = utils.get_logger(__name__)
 
 MODEL_ZOO = [PointNet, RandLANet, PointNet2]
+
+
 def get_neural_net_class(class_name: str) -> nn.Module:
     """A Class Factory to class of neural net based on class name.
 
@@ -27,6 +29,7 @@ def get_neural_net_class(class_name: str) -> nn.Module:
         if class_name in neural_net_class.__name__:
             return neural_net_class
     raise KeyError(f"Unknown class name {class_name}")
+
 
 class Model(LightningModule):
     """This LightningModule implements the logic for model trainin, validation, tests, and prediction.
@@ -201,7 +204,6 @@ class Model(LightningModule):
         logits = self.forward(batch)
         return {"logits": logits}
 
-
     def configure_optimizers(self):
         """Choose what optimizers and learning-rate schedulers to use in your optimization.
 
@@ -228,7 +230,3 @@ class Model(LightningModule):
         }
 
         return config
-
-
-
-

--- a/myria3d/models/modules/point_net.py
+++ b/myria3d/models/modules/point_net.py
@@ -37,11 +37,11 @@ class PointNet(nn.Module):
         """
         features = torch.cat([batch.pos, batch.x], axis=1)
         input_size = features.shape[0]
-        subsampling_size = (batch.batch_x == 0).sum()
+        subsampling_size = (batch.batch == 0).sum()
 
         f1 = self.mlp1(features)
         f2 = self.mlp2(f1)
-        context_vector = global_max_pool(f2, batch.batch_x)
+        context_vector = global_max_pool(f2, batch.batch)
         expanded_context_vector = (
             context_vector.unsqueeze(1)
             .expand((-1, subsampling_size, -1))

--- a/myria3d/models/modules/point_net.py
+++ b/myria3d/models/modules/point_net.py
@@ -30,10 +30,11 @@ class PointNet(nn.Module):
         self.lin = Linear(d3[-1], self.num_classes)
 
     def forward(self, batch):
-        """
+        """Forward pass.
+
         Object batch is a PyG data.Batch
         Tensors pos and x (features) are in long format (B*N, M) expected by pyG methods.
-        
+
         """
         features = torch.cat([batch.pos, batch.x], axis=1)
         input_size = features.shape[0]

--- a/myria3d/models/modules/point_net.py
+++ b/myria3d/models/modules/point_net.py
@@ -31,8 +31,9 @@ class PointNet(nn.Module):
 
     def forward(self, batch):
         """
-        Object batch is a PyG data.Batch, as defined in custom collate_fn.
+        Object batch is a PyG data.Batch
         Tensors pos and x (features) are in long format (B*N, M) expected by pyG methods.
+        
         """
         features = torch.cat([batch.pos, batch.x], axis=1)
         input_size = features.shape[0]

--- a/myria3d/models/modules/point_net2.py
+++ b/myria3d/models/modules/point_net2.py
@@ -1,0 +1,91 @@
+from numbers import Number
+import torch
+from torch_geometric.nn import MLP, knn_interpolate
+import torch
+import torch.nn.functional as F
+from torch_geometric.nn import MLP, PointConv, fps, global_max_pool, radius
+
+
+class SAModule(torch.nn.Module):
+    def __init__(self, ratio, r, nn):
+        super().__init__()
+        self.ratio = ratio
+        self.r = r
+        self.conv = PointConv(nn, add_self_loops=False)
+
+    def forward(self, x, pos, batch):
+        idx = fps(pos, batch, ratio=self.ratio)
+        row, col = radius(
+            pos,
+            pos[idx],
+            self.r,
+            batch,
+            batch[idx],
+            max_num_neighbors=64,
+            num_workers=4,
+        )
+        edge_index = torch.stack([col, row], dim=0)
+        x_dst = None if x is None else x[idx]
+        x = self.conv((x, x_dst), (pos, pos[idx]), edge_index)
+        pos, batch = pos[idx], batch[idx]
+        return x, pos, batch
+
+
+class GlobalSAModule(torch.nn.Module):
+    def __init__(self, nn):
+        super().__init__()
+        self.nn = nn
+
+    def forward(self, x, pos, batch):
+        x = self.nn(torch.cat([x, pos], dim=1))
+        x = global_max_pool(x, batch)
+        pos = pos.new_zeros((x.size(0), 3))
+        batch = torch.arange(x.size(0), device=batch.device)
+        return x, pos, batch
+
+
+class FPModule(torch.nn.Module):
+    def __init__(self, k, nn):
+        super().__init__()
+        self.k = k
+        self.nn = nn
+
+    def forward(self, x, pos, batch, x_skip, pos_skip, batch_skip):
+        x = knn_interpolate(x, pos, pos_skip, batch, batch_skip, k=self.k)
+        if x_skip is not None:
+            x = torch.cat([x, x_skip], dim=1)
+        x = self.nn(x)
+        return x, pos_skip, batch_skip
+
+
+class PointNet2(torch.nn.Module):
+    def __init__(self, hparams_net: dict):
+        super().__init__()
+        # d_in accounts for both `pos` and node features.
+
+        d_in = hparams_net.get("d_in", 9)
+        num_features = d_in - 3
+        num_classes = hparams_net.get("num_classes", 2)
+        r1 = hparams_net.get("r1", 2 / 50)
+        r2 = hparams_net.get("r2", 4 / 50)
+
+        self.sa1_module = SAModule(0.2, r1, MLP([d_in, 64, 64, 128]))
+        self.sa2_module = SAModule(0.25, r2, MLP([128 + 3, 128, 128, 256]))
+        self.sa3_module = GlobalSAModule(MLP([256 + 3, 256, 512, 1024]))
+
+        self.fp3_module = FPModule(1, MLP([1024 + 256, 256, 256]))
+        self.fp2_module = FPModule(3, MLP([256 + 128, 256, 128]))
+        self.fp1_module = FPModule(3, MLP([128 + num_features, 128, 128, 128]))
+        self.mlp = MLP([128, 128, 128, num_classes], dropout=0.5, batch_norm=False)
+
+    def forward(self, data):
+        sa0_out = (data.x, data.pos, data.batch)
+        sa1_out = self.sa1_module(*sa0_out)
+        sa2_out = self.sa2_module(*sa1_out)
+        sa3_out = self.sa3_module(*sa2_out)
+
+        fp3_out = self.fp3_module(*sa3_out, *sa2_out)
+        fp2_out = self.fp2_module(*fp3_out, *sa1_out)
+        x, _, _ = self.fp1_module(*fp2_out, *sa0_out)
+
+        return self.mlp(x)

--- a/myria3d/models/modules/point_net2.py
+++ b/myria3d/models/modules/point_net2.py
@@ -1,9 +1,12 @@
-from numbers import Number
 import torch
-from torch_geometric.nn import MLP, knn_interpolate
-import torch
-import torch.nn.functional as F
-from torch_geometric.nn import MLP, PointConv, fps, global_max_pool, radius
+from torch_geometric.nn import (
+    knn_interpolate,
+    MLP,
+    PointConv,
+    fps,
+    global_max_pool,
+    radius,
+)
 
 
 class SAModule(torch.nn.Module):

--- a/myria3d/models/modules/randla_net.py
+++ b/myria3d/models/modules/randla_net.py
@@ -89,7 +89,7 @@ class RandLANet(nn.Module):
         """
 
         input = torch.cat([batch.pos, batch.x], axis=1)
-        chunks = torch.split(input, len(batch.pos) // batch.num_batches)
+        chunks = torch.split(input, len(batch.pos) // batch.num_graphs)
         input = torch.stack(chunks)  # B, N, 3+F
 
         N = input.size(1)
@@ -367,7 +367,7 @@ def knn_compact(
         Tuple[torch.Tensor,torch.Tensor]: y_idx, x_idx assignment index, in range [0, batch_size[
 
     """
-    num_batches = len(pos_x)
+    num_graphs = len(pos_x)
 
     pos_x_long = torch.cat([sample_pos for sample_pos in pos_x])  # (N, 3)
     batch_x_long = torch.cat(
@@ -390,7 +390,7 @@ def knn_compact(
 
     # Get back to compact shape
     batch_size_y = len(pos_y[1])
-    compact_shape_y = (num_batches, batch_size_y, -1)
+    compact_shape_y = (num_graphs, batch_size_y, -1)
     x_idx = x_idx_long.view(compact_shape_y)
     y_idx = y_idx_long.view(compact_shape_y)
 

--- a/myria3d/predict.py
+++ b/myria3d/predict.py
@@ -54,17 +54,7 @@ def predict(config: DictConfig) -> str:
 
     for batch in tqdm(datamodule.predict_dataloader()):
         batch.to(device)
-        # logits = model.predict_step(batch)
-        # PErfect for test
-        logits = (
-            torch.nn.functional.one_hot(
-                batch.y,
-                num_classes=len(
-                    datamodule.dataset_description.get("classification_dict")
-                ),
-            )
-            * 10
-        )
+        logits = model.predict_step(batch)["logits"]
         itp.store_predictions(
             logits, batch.pos_sampled_copy, batch.batch, batch.idx_in_original_cloud
         )

--- a/package_metadata.yaml
+++ b/package_metadata.yaml
@@ -1,4 +1,4 @@
-__version__: "2.0.3"
+__version__: "2.1.0"
 __name__: "myria3d"
 __url__: "https://github.com/IGNF/myria3d"
 __description__: "Multiclass Semantic Segmentation for Lidar Point Cloud"

--- a/tests/myria3d/data/test_transforms.py
+++ b/tests/myria3d/data/test_transforms.py
@@ -12,7 +12,7 @@ def test_TargetTransform_with_valid_config():
     tt = TargetTransform(classification_preprocessing_dict, classification_dict)
 
     y = np.array([1, 1, 2, 2, 6, 6])
-    data = torch_geometric.data.Data(x=None, y=y, y_copy=y)
+    data = torch_geometric.data.Data(x=None, y=y)
     assert np.array_equal(tt(data).y, np.array([0, 0, 0, 0, 1, 1]))
 
 

--- a/tests/myria3d/models/modules/test_point_net2.py
+++ b/tests/myria3d/models/modules/test_point_net2.py
@@ -1,0 +1,25 @@
+import torch
+from torch_geometric.data import Batch
+from myria3d.models.modules.randla_net import RandLANet
+
+
+def test_fake_run_pointnet2():
+    """Documents expected data format and make a forward pass with RandLa-Net"""
+    num_euclidian_dimensions = 3
+    num_features = 9
+    d_in = num_euclidian_dimensions + num_features
+    num_classes = 6
+    hparams_net = {
+        "d_in": d_in,
+        "r1": 2/50,
+        "r2": 4/50,
+        "num_classes": num_classes,
+    }
+    batch = Batch()
+    batch.num_graphs = 4
+    num_points = 12500
+    batch.pos = torch.rand((num_points * batch.num_graphs, num_euclidian_dimensions))
+    batch.x = torch.rand((num_points * batch.num_graphs, num_features))
+    rln = RandLANet(hparams_net)
+    output = rln(batch)
+    assert output.shape == torch.Size([num_points * batch.num_graphs, num_classes])

--- a/tests/myria3d/models/modules/test_randla_net.py
+++ b/tests/myria3d/models/modules/test_randla_net.py
@@ -18,9 +18,9 @@ def test_fake_run_randlanet():
     }
     batch = Batch()
     batch.num_graphs = 4
-    batch_size = 12500
-    batch.pos = torch.rand((batch_size * batch.num_graphs, num_euclidian_dimensions))
-    batch.x = torch.rand((batch_size * batch.num_graphs, num_features))
+    num_points = 12500
+    batch.pos = torch.rand((num_points * batch.num_graphs, num_euclidian_dimensions))
+    batch.x = torch.rand((num_points * batch.num_graphs, num_features))
     rln = RandLANet(hparams_net)
     output = rln(batch)
-    assert output.shape == torch.Size([batch_size * batch.num_graphs, num_classes])
+    assert output.shape == torch.Size([num_points * batch.num_graphs, num_classes])

--- a/tests/myria3d/models/modules/test_randla_net.py
+++ b/tests/myria3d/models/modules/test_randla_net.py
@@ -17,10 +17,10 @@ def test_fake_run_randlanet():
         "num_classes": num_classes,
     }
     batch = Batch()
-    batch.num_batches = 4
+    batch.num_graphs = 4
     batch_size = 12500
-    batch.pos = torch.rand((batch_size * batch.num_batches, num_euclidian_dimensions))
-    batch.x = torch.rand((batch_size * batch.num_batches, num_features))
+    batch.pos = torch.rand((batch_size * batch.num_graphs, num_euclidian_dimensions))
+    batch.x = torch.rand((batch_size * batch.num_graphs, num_features))
     rln = RandLANet(hparams_net)
     output = rln(batch)
-    assert output.shape == torch.Size([batch_size * batch.num_batches, num_classes])
+    assert output.shape == torch.Size([batch_size * batch.num_graphs, num_classes])

--- a/tests/myria3d/test_train_and_predict.py
+++ b/tests/myria3d/test_train_and_predict.py
@@ -132,6 +132,39 @@ def test_PointNet_overfitting(isolated_toy_dataset_tmpdir, tmpdir):
     assert improvement >= 0.45
 
 
+@pytest.mark.slow()
+def test_PointNet2_overfitting(isolated_toy_dataset_tmpdir, tmpdir):
+    """Check ability to overfit with PointNet.
+
+    Check that overfitting a single batch from a toy dataset, for 30 epochs, results
+    in significanly lower training loss.
+
+    Args:
+        isolated_toy_dataset_tmpdir (fixture -> str): directory to toy dataset
+        tmpdir (fixture -> str): temporary directory.
+
+    """
+    tmp_paths_overrides = _make_list_of_necesary_hydra_overrides_with_tmp_paths(
+        isolated_toy_dataset_tmpdir, tmpdir
+    )
+    cfg = make_default_hydra_cfg(
+        overrides=tmp_paths_overrides
+        + [
+            "experiment=PointNet2Debug",  # Use an experiment designed for overfitting a batch...
+            "datamodule.batch_size=2",  # Smaller batch size for faster overfit
+            # Define the task as a classification of all (1 and 2) vs. 6=building
+            "++datamodule.dataset_description.classification_preprocessing_dict={2:1}",
+        ]
+    )
+    train(cfg)
+
+    # Assert that there was a significative improvement i.e. the model learns.
+    metrics = _get_metrics_df_from_tmpdir(tmpdir)
+    iou = metrics["train/iou_CLASS_building"].dropna()
+    improvement = iou.iloc[-1] - iou.iloc[0]
+    assert improvement >= 0.55
+
+
 def test_RandLaNet_test_right_after_training(
     isolated_toy_dataset_tmpdir, one_epoch_trained_RandLaNet_checkpoint, tmpdir
 ):

--- a/tests/myria3d/test_train_and_predict.py
+++ b/tests/myria3d/test_train_and_predict.py
@@ -253,9 +253,9 @@ def test_run_test_with_trained_model_on_large_las(
         tmpdir (fixture -> str): temporary directory.
 
     """
-    pytest.xfail(
-        reason="Modle is currently too memory intensive to test on a full LAS in self-hosted action-runner."
-    )
+    # pytest.xfail(
+    #     reason="Model is currently too memory intensive to test on a full LAS in self-hosted action-runner."
+    # )
 
     if not osp.isfile(TRAINED_MODEL_PATH):
         pytest.xfail(reason=f"No access to {TRAINED_MODEL_PATH} in this environment.")
@@ -273,10 +273,16 @@ def test_run_test_with_trained_model_on_large_las(
     )
     train(cfg_test_using_trained_model)
     metrics = _get_metrics_df_from_tmpdir(tmpdir)
-    # TODO: reference values to be better defined
-    assert metrics["test/iou_CLASS_unclassified"][0] >= 0.55
-    assert metrics["test/iou_CLASS_ground"][0] >= 0.80
-    assert metrics["test/iou_CLASS_building"][0] >= 0.80
+
+    # Reference value of IoU of subsampled cloud point (current method)
+    assert metrics["test/iou_CLASS_building"][0] >= 0.74
+    assert metrics["test/iou_CLASS_ground"][0] >= 0.77
+    assert metrics["test/iou_CLASS_unclassified"][0] >= 0.49
+
+    # Reference value with full interpolation would be
+    # assert metrics["test/iou_CLASS_unclassified"][0] >= 0.55
+    # assert metrics["test/iou_CLASS_ground"][0] >= 0.80
+    # assert metrics["test/iou_CLASS_building"][0] >= 0.80
 
 
 def test_predict_with_trained_model_on_toy_dataset(tmpdir):


### PR DESCRIPTION
Interpolation first happens only within a receptive field ; interpolated logits are then summed if multiple predictions were made for a single point.
Evaluation of IoU is simplified in test to only be computed on predicted points (that can be synthesis points from gridsampling).
Transforms can now be configurated from config files, to e.g. add augmentations.
PointNet++ is supported, and is tested with an overfit test on the toy dataset. This is to ilustrate that models from https://github.com/pyg-team/pytorch_geometric/tree/master/examples can easily be integrated. One must be careful for model parameters, and how they interpolay with data transformations (e.g. adapting radius if the positions were normalized).