### PR TITLE
Optimize memory usage during interpolation+saving

### DIFF
--- a/myria3d/models/interpolation.py
+++ b/myria3d/models/interpolation.py
@@ -136,6 +136,9 @@ class Interpolator:
                 f"Saving predicted classes to channel {self.predicted_classification_channel}."
                 "Channel name can be changed by setting `predict.interpolator.predicted_classification_channel`."
             )
+            del preds
+
+        del logits
 
         if self.entropy_channel:
             las[self.entropy_channel] = Categorical(probs=probas).entropy()

--- a/myria3d/models/interpolation.py
+++ b/myria3d/models/interpolation.py
@@ -8,7 +8,7 @@ import torch
 from torch.distributions import Categorical
 from torch_scatter import scatter_sum
 
-from myria3d.pctl.dataset.utils import get_pdal_reader
+from myria3d.pctl.dataset.utils import get_pdal_info_metadata, get_pdal_reader
 
 log = logging.getLogger(__name__)
 
@@ -84,7 +84,7 @@ class Interpolator:
         self.idx_in_full_cloud_list += idx_in_original_cloud
 
     @torch.no_grad()
-    def reduce_predicted_logits(self, las) -> torch.Tensor:
+    def reduce_predicted_logits(self, nb_points) -> torch.Tensor:
         """Interpolate logits to points without predictions using an inverse-distance weightning scheme.
 
         Returns:
@@ -100,7 +100,7 @@ class Interpolator:
 
         # We scatter_sum logits based on idx, in case there are multiple predictions for a point.
         # scatter_sum reorders logitsbased on index,they therefore match las order.
-        reduced_logits = torch.zeros((len(las), logits.size(1)))
+        reduced_logits = torch.zeros((nb_points, logits.size(1)))
         scatter_sum(logits, torch.from_numpy(idx_in_full_cloud), out=reduced_logits, dim=0)
         # reduced_logits contains logits ordered by their idx in original cloud !
         # Warning : some points may not contain any predictions if they were in small areas.
@@ -120,25 +120,32 @@ class Interpolator:
 
         """
         basename = os.path.basename(raw_path)
-        las = self.load_full_las_for_update(src_las=raw_path)
-        logits = self.reduce_predicted_logits(las)
+        # Read number of points only from las metadata in order to minimize memory usage
+        nb_points = get_pdal_info_metadata(raw_path)["count"]
+        logits = self.reduce_predicted_logits(nb_points)
 
         probas = torch.nn.Softmax(dim=1)(logits)
+
+        if self.predicted_classification_channel:
+            preds = torch.argmax(logits, dim=1)
+            preds = np.vectorize(self.reverse_mapper.get)(preds)
+
+        del logits
+
+        # Read las after fetching all information to write into it
+        las = self.load_full_las_for_update(src_las=raw_path)
+
         for idx, class_name in enumerate(self.classification_dict.values()):
             if class_name in self.probas_to_save:
                 las[class_name] = probas[:, idx]
 
         if self.predicted_classification_channel:
-            preds = torch.argmax(logits, dim=1)
-            preds = np.vectorize(self.reverse_mapper.get)(preds)
             las[self.predicted_classification_channel] = preds
             log.info(
                 f"Saving predicted classes to channel {self.predicted_classification_channel}."
                 "Channel name can be changed by setting `predict.interpolator.predicted_classification_channel`."
             )
             del preds
-
-        del logits
 
         if self.entropy_channel:
             las[self.entropy_channel] = Categorical(probs=probas).entropy()

--- a/myria3d/pctl/dataset/utils.py
+++ b/myria3d/pctl/dataset/utils.py
@@ -1,5 +1,7 @@
 import glob
+import json
 import math
+import subprocess as sp
 from numbers import Number
 from typing import Dict, List, Literal, Union
 
@@ -81,6 +83,23 @@ def get_pdal_reader(las_path: str) -> pdal.Reader.las:
         override_srs="EPSG:2154",
     )
 
+
+def get_pdal_info_metadata(las_path: str) -> Dict:
+    """Read las metadata using pdal info
+    Args:
+        las_path (str): input LAS path to read.
+    Returns:
+        (dict): dictionary containing metadata from the las file
+    """
+    r = sp.run(["pdal", "info", "--metadata", las_path], capture_output=True)
+    if r.returncode == 1:
+        msg = r.stderr.decode()
+        raise RuntimeError(msg)
+
+    output = r.stdout.decode()
+    json_info = json.loads(output)
+
+    return json_info["metadata"]
 
 # hdf5, iterable
 


### PR DESCRIPTION
This branch contains 2 changes:
- delete used variables that have a high memory usage
- read las file only when needed

Here is the observed improvement (x is time, y RAM consumption)
![comparaison_ram_main_devbranch](https://user-images.githubusercontent.com/120112647/208114671-d5c30de9-851b-4fcc-b43c-1a4eb9a40748.png)
The red arrow shows the change in memory usage due to deleting variables
The purple one shows the effect of delaying the las reading (the peak in memory happens later)