### PR TITLE
Fix small error in dataset description of `proto151`

### DIFF
--- a/configs/dataset_description/20220607_151_dalles_proto.yaml
+++ b/configs/dataset_description/20220607_151_dalles_proto.yaml
@@ -5,9 +5,10 @@ _convert_: all  # For omegaconf struct to be converted to python dictionnaries
 # 160: antenna -> lasting_above
 # 161: wind_turbines -> lasting_above
 # 162: pylon -> lasting_above
-# 65: noise --> -1 (to ignore them in inference process, but tey will still be included in the final output cloud).
-# Some trash classes were left in this dataset We do not drop them (i.e. map them to -1) to avoid unintended conflict in production.
-classification_preprocessing_dict: {3: 5, 4: 5, 160: 64, 161: 64, 162: 64, 0: 1, 7: 1, 46: 1, 47: 1, 48: 1, 49: 1, 50: 1, 51: 1, 52: 1, 53: 1, 54: 1, 55: 1, 56: 1, 57: 1, 58: 1, 64: 1, 66: 1, 67: 1, 77: 1, 155: 1, 204: 1}
+# Note: other codes are also mapped to 1 (unclassified) : they were left in this dataset during its creation, and are a minority.
+# We do not drop them (i.e. we do not map them to the reserved noise code (65) during training) 
+# in order to avoid unintended conflict in production.
+classification_preprocessing_dict: {3: 5, 4: 5, 160: 64, 161: 64, 162: 64, 0: 1, 7: 1, 46: 1, 47: 1, 48: 1, 49: 1, 50: 1, 51: 1, 52: 1, 53: 1, 54: 1, 55: 1, 56: 1, 57: 1, 58: 1, 66: 1, 67: 1, 77: 1, 155: 1, 204: 1}
 
 # classification_dict = {code_int: name_str, ...} and MUST be sorted (increasing order).
 classification_dict: {1: "unclassified", 2: "ground", 5: vegetation, 6: "building", 9: water, 17: bridge, 64: lasting_above}

--- a/myria3d/pctl/transforms/transforms.py
+++ b/myria3d/pctl/transforms/transforms.py
@@ -216,7 +216,9 @@ class TargetTransform(BaseTransform):
     def _set_mapper(self, classification_dict):
         """Set mapper from source classification code to consecutive integers."""
         d = {class_code: class_index for class_index, class_code in enumerate(classification_dict.keys())}
-        d.update({65: 65})  # code -1 is for artefacts and is used in DropPointsByClass.
+        # Here we update the dict so that code 65 remains unchanged.
+        # Indeed, 65 is reserved for noise/artefacts points, that will be deleted by transform "DropPointsByClass".
+        d.update({65: 65})  
         self.mapper = np.vectorize(lambda class_code: d.get(class_code))
 
 

--- a/myria3d/pctl/transforms/transforms.py
+++ b/myria3d/pctl/transforms/transforms.py
@@ -218,7 +218,7 @@ class TargetTransform(BaseTransform):
         d = {class_code: class_index for class_index, class_code in enumerate(classification_dict.keys())}
         # Here we update the dict so that code 65 remains unchanged.
         # Indeed, 65 is reserved for noise/artefacts points, that will be deleted by transform "DropPointsByClass".
-        d.update({65: 65})  
+        d.update({65: 65})
         self.mapper = np.vectorize(lambda class_code: d.get(class_code))
 
 


### PR DESCRIPTION
Code 64 (`lasting_above` = `sursol pérenne`) was incorrectly mapped to code 1 (`unclassified).`

In our training dataset most points for `lasting_above` class had more precise coding like `antenna`, `pylone`, `wind_turbines`, but some other objects might have been considered as unclassified during training. 

- **The impact on the model should be marginal and only on some rare, unspecific `lasting_above` objects** 
- **The impact on our production at IGN should be null** since predictions for class `lasting_above`/`unclassified` are currently not used. 