### PR TITLE
fix: support edge case where src LAZ has no valid patch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # main
 
+### 3.4.9
+- Support edge-case where source LAZ has no valid subtile (i.e. pre_filter=False for all candidate subtiles) during hdf5 creation
+
 ### 3.4.8
 - Raise an informative error in case of unexpected task_name
 

--- a/myria3d/pctl/dataset/hdf5.py
+++ b/myria3d/pctl/dataset/hdf5.py
@@ -285,4 +285,6 @@ def create_hdf5(
                     )
 
                 # A termination flag to report that all samples for this point cloud were included in the df5 file.
-                hdf5_file[split][basename].attrs["is_complete"] = True
+                # Group may not have been created if source cloud had no patch passing the pre_filter step, hence the "if" here.
+                if basename in hdf5_file[split]:
+                    hdf5_file[split][basename].attrs["is_complete"] = True

--- a/myria3d/pctl/dataset/hdf5.py
+++ b/myria3d/pctl/dataset/hdf5.py
@@ -234,7 +234,7 @@ def create_hdf5(
             # Useful in case data preparation was interrupted.
             with h5py.File(hdf5_file_path, "a") as hdf5_file:
                 if basename in hdf5_file[split] and "is_complete" not in hdf5_file[split][basename].attrs:
-                    del hdf5_file[basename]
+                    del hdf5_file[split][basename]
                     # Parse and add subtiles to split group.
             with h5py.File(hdf5_file_path, "a") as hdf5_file:
                 if basename in hdf5_file[split]:

--- a/package_metadata.yaml
+++ b/package_metadata.yaml
@@ -1,4 +1,4 @@
-__version__: "3.4.8"
+__version__: "3.4.9"
 __name__: "myria3d"
 __url__: "https://github.com/IGNF/myria3d"
 __description__: "Deep Learning for the Semantic Segmentation of Aerial Lidar Point Clouds"


### PR DESCRIPTION
Handling a special case, usually due to invalid input data but that can also happen in normal situations.

I also correct a line for the deletion of incomplete hdf5 group. The wrong group was deleted, which would just mean starting the whole creation of hdf5 groups for a split (train/test/val) instead of resuming to where the creation was stopped.