### PR TITLE
Add a configuration for 2x3 GPUs training without gradient accumulation

### DIFF
--- a/configs/experiment/RandLaNet_base_run_FR-2x3GPUs-MixedPrecision.yaml
+++ b/configs/experiment/RandLaNet_base_run_FR-2x3GPUs-MixedPrecision.yaml
@@ -1,0 +1,19 @@
+# @package _global_
+defaults:
+  - RandLaNet_base_run_FR.yaml
+
+logger:
+  comet:
+    experiment_name: "RandLaNet_base_run_FR-2x3GPUs-MixedPrecision"
+
+
+# 2 nodes x 3 GPUs - No gradient accumulation. 
+# This is equivalent to training with 2 GPUs with gradients accumulated 3 times.
+# Consider trying precision=bf16 once version of pytorch/pytorch-geometric/pytorch-scatter are updated.
+trainer:
+  strategy: ddp_find_unused_parameters_false
+  accelerator: gpu
+  num_nodes: 2
+  gpus: 3
+  accumulate_grad_batches: 1
+  precision: 16

--- a/configs/experiment/RandLaNet_base_run_FR-2x3GPUs.yaml
+++ b/configs/experiment/RandLaNet_base_run_FR-2x3GPUs.yaml
@@ -4,16 +4,15 @@ defaults:
 
 logger:
   comet:
-    experiment_name: "RandLaNet_base_run_FR-2x3GPUs-MixedPrecision"
+    experiment_name: "RandLaNet_base_run_FR-2x3GPUs"
 
 
 # 2 nodes x 3 GPUs - No gradient accumulation. 
 # This is equivalent to training with 2 GPUs with gradients accumulated 3 times.
-# Consider trying precision=bf16 once version of pytorch/pytorch-geometric/pytorch-scatter are updated.
+# Setting precision=16 did not bring any speed improvement for Lidar HD data and RandLa-Net model.
 trainer:
   strategy: ddp_find_unused_parameters_false
   accelerator: gpu
   num_nodes: 2
   gpus: 3
   accumulate_grad_batches: 1
-  precision: 16

--- a/configs/experiment/RandLaNet_base_run_FR-2x3GPUs.yaml
+++ b/configs/experiment/RandLaNet_base_run_FR-2x3GPUs.yaml
@@ -14,5 +14,5 @@ trainer:
   strategy: ddp_find_unused_parameters_false
   accelerator: gpu
   num_nodes: 2
-  gpus: 3
+  devices: 3
   accumulate_grad_batches: 1

--- a/configs/experiment/RandLaNet_base_run_FR-MultiGPU.yaml
+++ b/configs/experiment/RandLaNet_base_run_FR-MultiGPU.yaml
@@ -4,11 +4,11 @@ defaults:
 
 logger:
   comet:
-    experiment_name: "Pyg RandLaNet - FR Data - 2xGPUs"
+    experiment_name: "RandLaNet_base_run_FR-2xGPUs"
 
 trainer:
   strategy: ddp_find_unused_parameters_false
-  # Replace by gpu to simulate multi-gpus training.
+  # Replace by cpu to simulate multi-cpus training.
   accelerator: gpu
   num_processes: 2
   gpus: 2


### PR DESCRIPTION
Configuration précédente : 2 GPUs, accumulation de gradient x3, batch size de 10. --> 116h /115 epochs -> ~ 1 h / epoch 
Configuration proposée : 2 nodes x 3 GPUs, sans accumulation de gradient, batch size de 10 -> 41.5h / 100 epochs -> 0.415h/epoch.

>2 division de temps d'entrainement, pour un résultat strictement équivalent.

![train_iou_epoch,val_iou_epoch](https://github.com/IGNF/myria3d/assets/11660435/b033221c-0c72-4d59-9cad-4c5d3ae130db)

