### PR TITLE
Log confusion matrices after each epoch 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+### 3.7.2
+- fix: do not mix the two way to log IoUs to avoid known lightning [Common Pitfalls](https://lightning.ai/docs/torchmetrics/stable/pages/lightning.html#common-pitfalls).
+
 ### 3.7.1
 - fix: edge case when saving predictions under Classification channel, without saving entropy.
 

--- a/myria3d/callbacks/comet_callbacks.py
+++ b/myria3d/callbacks/comet_callbacks.py
@@ -33,7 +33,7 @@ def get_comet_logger(trainer: Trainer) -> Optional[CometLogger]:
                 return logger
 
     warnings.warn(
-        "You are using comet related callback, but CometLogger was not found for some reason...",
+        "You are using comet related functions, but trainer has no CometLogger among its loggers.",
         UserWarning,
     )
     return None
@@ -71,3 +71,16 @@ class LogLogsPath(Callback):
             log_path = os.getcwd()
             log.info(f"----------------\n LOGS DIR is {log_path}\n ----------------")
             logger.experiment.log_parameter("experiment_logs_dirpath", log_path)
+
+
+def log_comet_cm(lightning_module, confmat, phase):
+    logger = get_comet_logger(trainer=lightning_module)
+    if logger:
+        labels = list(lightning_module.hparams.classification_dict.values())
+        logger.experiment.log_confusion_matrix(
+            matrix=confmat.cpu().numpy().tolist(),
+            labels=labels,
+            file_name=f"{phase}-confusion-matrix",
+            title="{phase} confusion matrix",
+            epoch=lightning_module.current_epoch,
+        )

--- a/package_metadata.yaml
+++ b/package_metadata.yaml
@@ -1,4 +1,4 @@
-__version__: "3.7.1"
+__version__: "3.7.2"
 __name__: "myria3d"
 __url__: "https://github.com/IGNF/myria3d"
 __description__: "Deep Learning for the Semantic Segmentation of Aerial Lidar Point Clouds"


### PR DESCRIPTION
- Log confusion matrices to Comet
- Small refactor of IoUs computations to be sure that only one way of logging them is used

![image](https://github.com/IGNF/myria3d/assets/11660435/e7e941c1-8cad-41a8-8db1-1f1aafb373e9)
