### PR TITLE
Fix type error in DropPointsByClass

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.4.0
+    rev: v4.5.0
     hooks:
       # list of supported hooks: https://pre-commit.com/hooks.html
       - id: trailing-whitespace
@@ -12,26 +12,26 @@ repos:
 
   # python code formatting
   - repo: https://github.com/psf/black
-    rev: 20.8b1
+    rev: 24.2.0
     hooks:
       - id: black
         args: [--line-length, "99"]
 
   # python import sorting
   - repo: https://github.com/PyCQA/isort
-    rev: 5.8.0
+    rev: 5.13.2
     hooks:
       - id: isort
 
   # yaml formatting
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v2.3.0
+    rev: v4.0.0-alpha.8
     hooks:
       - id: prettier
         types: [yaml]
 
   # python code analysis
   - repo: https://github.com/PyCQA/flake8
-    rev: 3.9.2
+    rev: 7.0.0
     hooks:
       - id: flake8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # CHANGELOG
+### 3.8.2
+- fix: type error in edge case when dropping points in transforms
+
 ### 3.8.1
 - fix: propagate input las format to output las (in particular epsg which comes either from input or config)
 

--- a/myria3d/pctl/transforms/transforms.py
+++ b/myria3d/pctl/transforms/transforms.py
@@ -36,6 +36,9 @@ def subsample_data(data, num_nodes, choice):
             continue
         elif torch.is_tensor(item) and item.size(0) == num_nodes and item.size(0) != 1:
             data[key] = item[choice]
+        elif isinstance(item, np.ndarray) and item.shape[0] == num_nodes and item.shape[0] != 1:
+            data[key] = item[choice]
+
     return data
 
 
@@ -234,7 +237,5 @@ class DropPointsByClass(BaseTransform):
         if points_to_drop.sum() > 0:
             points_to_keep = torch.logical_not(points_to_drop)
             data = subsample_data(data, num_nodes=data.num_nodes, choice=points_to_keep)
-            # Here we also subsample these idx since we do not need to interpolate these points back
-            if "idx_in_original_cloud" in data:
-                data.idx_in_original_cloud = data.idx_in_original_cloud[points_to_keep]
+
         return data

--- a/package_metadata.yaml
+++ b/package_metadata.yaml
@@ -1,4 +1,4 @@
-__version__: "3.8.1"
+__version__: "3.8.2"
 __name__: "myria3d"
 __url__: "https://github.com/IGNF/myria3d"
 __description__: "Deep Learning for the Semantic Segmentation of Aerial Lidar Point Clouds"

--- a/tests/myria3d/models/test_model.py
+++ b/tests/myria3d/models/test_model.py
@@ -1,0 +1,28 @@
+import hydra
+from pytorch_lightning import LightningDataModule
+from tests.conftest import make_default_hydra_cfg
+
+from myria3d.models.model import Model
+
+
+def test_model_get_batch_tensor_by_enumeration():
+    config = make_default_hydra_cfg(
+        overrides=[
+            "predict.src_las=tests/data/toy_dataset_src/862000_6652000.classified_toy_dataset.100mx100m.las",
+            "datamodule.epsg=2154",
+            "work_dir=./../../..",
+            "datamodule.subtile_width=1",
+            "datamodule.hdf5_file_path=null",
+        ]
+    )
+
+    datamodule: LightningDataModule = hydra.utils.instantiate(config.datamodule)
+    datamodule._set_predict_data(config.predict.src_las)
+
+    model = Model(
+        neural_net_class_name="PyGRandLANet",
+        neural_net_hparams=dict(num_features=2, num_classes=7),
+    )
+    for batch in datamodule.predict_dataloader():
+        # Check that no error is raised ("TypeError: object of type 'numpy.int64' has no len()")
+        _ = model._get_batch_tensor_by_enumeration(batch.idx_in_original_cloud)


### PR DESCRIPTION
A `TypeError: object of type 'numpy.int64' has no len()` was raised in some specific use case when using DropPointsByClass with batches containing a single point (the numpy array was transformed to an integer)