### PR TITLE
Add a forgotten load_dotenv

### DIFF
--- a/run.py
+++ b/run.py
@@ -125,6 +125,7 @@ if __name__ == "__main__":
         launch_predict()
 
     elif task_name == TASK_NAMES.HDF5.value:
+        dotenv.load_dotenv(override=True)
         launch_hdf5()
 
     else:


### PR DESCRIPTION
A load_dotenv line has been forgotten in the "create_hdf5" option.
This is a fix